### PR TITLE
ELOAD-361 Read Long coordinates from Mongo

### DIFF
--- a/opencga-account/pom.xml
+++ b/opencga-account/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/opencga-analysis/pom.xml
+++ b/opencga-analysis/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/opencga-app/pom.xml
+++ b/opencga-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/opencga-catalog/pom.xml
+++ b/opencga-catalog/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/opencga-lib/pom.xml
+++ b/opencga-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/opencga-server/pom.xml
+++ b/opencga-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-app/pom.xml
+++ b/opencga-storage/opencga-storage-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-core/pom.xml
+++ b/opencga-storage/opencga-storage-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-hbase/pom.xml
+++ b/opencga-storage/opencga-storage-hbase/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-mongodb/pom.xml
+++ b/opencga-storage/opencga-storage-mongodb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga-storage</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantConverter.java
+++ b/opencga-storage/opencga-storage-mongodb/src/main/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantConverter.java
@@ -97,8 +97,8 @@ public class DBObjectToVariantConverter implements ComplexTypeConverter<Variant,
     @Override
     public Variant convertToDataModelType(DBObject object) {
         String chromosome = (String) object.get(CHROMOSOME_FIELD);
-        int start = (int) object.get(START_FIELD);
-        int end = (int) object.get(END_FIELD);
+        int start = getDbObjectNumericFieldAsInt(object.get(START_FIELD));
+        int end = getDbObjectNumericFieldAsInt(object.get(END_FIELD));
         String reference = (String) object.get(REFERENCE_FIELD);
         String alternate = (String) object.get(ALTERNATE_FIELD);
         Variant variant = new Variant(chromosome, start, end, reference, alternate);
@@ -146,6 +146,14 @@ public class DBObjectToVariantConverter implements ComplexTypeConverter<Variant,
             statsConverter.convertCohortsToDataModelType(stats, variant);
         }
         return variant;
+    }
+
+    private int getDbObjectNumericFieldAsInt(Object field) {
+        if (field instanceof Integer) {
+            return (int)field;
+        } else {
+            return Math.toIntExact((long)field);
+        }
     }
 
     @Override

--- a/opencga-storage/opencga-storage-mongodb/src/test/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantConverterTest.java
+++ b/opencga-storage/opencga-storage-mongodb/src/test/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantConverterTest.java
@@ -1,6 +1,5 @@
 package org.opencb.opencga.storage.mongodb.variant;
 
-import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
@@ -9,7 +8,9 @@ import com.mongodb.DBObject;
 import java.util.*;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.opencb.biodata.models.variant.VariantSourceEntry;
 import org.opencb.biodata.models.variant.Variant;
 import org.opencb.commons.utils.CryptoUtils;
@@ -26,6 +27,9 @@ public class DBObjectToVariantConverterTest {
     private BasicDBObject mongoVariant;
     private Variant variant;
     protected VariantSourceEntry variantSourceEntry;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -231,4 +235,13 @@ public class DBObjectToVariantConverterTest {
         assertEquals(variant, converted);
     }
 
+    @Test
+    public void testConvertVariantWithCoordinatesNotFittingInIntToDataModelTypeWillThrowException() {
+        mongoVariant.append(DBObjectToVariantConverter.START_FIELD, 12345678901L)
+                    .append(DBObjectToVariantConverter.END_FIELD, 12345678901L);
+
+        DBObjectToVariantConverter converter = new DBObjectToVariantConverter();
+        thrown.expect(ArithmeticException.class);
+        converter.convertToDataModelType(mongoVariant);
+    }
 }

--- a/opencga-storage/opencga-storage-mongodb/src/test/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantConverterTest.java
+++ b/opencga-storage/opencga-storage-mongodb/src/test/java/org/opencb/opencga/storage/mongodb/variant/DBObjectToVariantConverterTest.java
@@ -220,4 +220,15 @@ public class DBObjectToVariantConverterTest {
         assertEquals("1_1000_TAG_" + new String(CryptoUtils.encryptSha1(alt)), converter.buildStorageId(v3));
     }
 
+
+    @Test
+    public void testConvertVariantWithCoordinatesStoredInLongObjectToDataModelType() {
+        mongoVariant.append(DBObjectToVariantConverter.START_FIELD, new Long(variant.getStart()))
+                .append(DBObjectToVariantConverter.END_FIELD, new Long(variant.getStart()));
+
+        DBObjectToVariantConverter converter = new DBObjectToVariantConverter();
+        Variant converted = converter.convertToDataModelType(mongoVariant);
+        assertEquals(variant, converted);
+    }
+
 }

--- a/opencga-storage/pom.xml
+++ b/opencga-storage/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>opencga</artifactId>
-        <version>0.5.5</version>
+        <version>0.5.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.ac.ebi.eva</groupId>
     <artifactId>opencga</artifactId>
-    <version>0.5.5</version>
+    <version>0.5.6</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
A load pipeline execution (cow data) is failing in the stats step because some of the variants in the MongoDB database have variants stored as LongNumber. This PR skip those errors while still throwing an exception if the variant coordinates overrides int.